### PR TITLE
feat(tmux): update prefix, enable true color, add key bindings reference

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -1,3 +1,40 @@
+# =============================================================================
+# DEFAULT KEY BINDINGS REFERENCE (prefix = Ctrl+/)
+# =============================================================================
+# Sessions:
+#   prefix $          Rename session
+#   prefix d          Detach from session
+#   prefix s          List/switch sessions
+#   prefix (  )       Switch to previous/next session
+#
+# Windows:
+#   prefix c          New window
+#   prefix ,          Rename window         <- use this!
+#   prefix &          Kill window
+#   prefix n  p       Next/previous window
+#   prefix 0-9        Switch to window by number
+#   prefix w          List/switch windows
+#   prefix f          Find window by name
+#
+# Panes:
+#   prefix %          Split vertical        (overridden below to keep cwd)
+#   prefix "          Split horizontal      (overridden below to keep cwd)
+#   prefix x          Kill pane
+#   prefix z          Toggle pane zoom
+#   prefix {  }       Swap pane left/right
+#   prefix o          Cycle through panes
+#   prefix q          Show pane numbers
+#   prefix !          Break pane into window
+#
+# Copy mode:
+#   prefix [          Enter copy mode
+#   prefix ]          Paste buffer
+#
+# Misc:
+#   prefix ?          List all keybindings
+#   prefix t          Show clock
+# =============================================================================
+
 # https://github.com/seebi/tmux-colors-solarized/blob/master/tmuxcolors-256.conf
 set-option -g status-style bg=colour235,fg=colour136,default # bg=base02, fg=yellow
 
@@ -38,8 +75,8 @@ set -g status-left '#[default]'
 set -g status-right '#[default]'
 
 # C-b is not acceptable -- Vim uses it
-set-option -g prefix C-a
-bind-key C-a last-window
+set-option -g prefix C-_
+bind-key C-_ last-window
 
 # Start numbering at 1
 set -g base-index 1
@@ -55,7 +92,7 @@ setw -g aggressive-resize on
 # Allows us to use C-a a <command> to send commands to a TMUX session inside 
 # another TMUX session
 bind-key a send-prefix
-bind a send-prefix # jump to beginning of the line, C-a a
+bind _ send-prefix # send prefix through to inner session, C-_ _
 
 # Activity monitoring
 setw -g monitor-activity on
@@ -105,20 +142,6 @@ if-shell "test '#{$TMUX_VERSION_MAJOR} -gt 1 -o \( #{$TMUX_VERSION_MAJOR} -eq 1 
 if-shell "test '#{$TMUX_VERSION_MAJOR} -gt 1 -o \( #{$TMUX_VERSION_MAJOR} -eq 1 -a #{$TMUX_VERSION_MINOR} -ge 8 \)'" 'unbind "%"; bind % split-window -h -c "#{pane_current_path}"'
 
 
-# Colors
-# How to use true colors in vim under tmux? #1246 for 2.6 and higher
-# https://github.com/tmux/tmux/issues/1246:
-# set -g default-terminal "tmux-256color"
-# set -ga terminal-overrides ",*256col*:Tc"
-# 2.5 and lower:
-# set -g default-terminal "screen-256color"
-
-# Doesn't work on iterm2 / mac
-# if-shell "test '\( #{$TMUX_VERSION_MAJOR} -eq 2 -a #{$TMUX_VERSION_MINOR} -ge 6 \)'" 'set -g default-terminal "tmux-256color"'
-# if-shell "test '\( #{$TMUX_VERSION_MAJOR} -eq 2 -a #{$TMUX_VERSION_MINOR} -ge 6 \)'" 'set -ga terminal-overrides ",*256col*:Tc"'
-
-# Try screen256-color (https://github.com/tmux/tmux/issues/622):
-if-shell "test '\( #{$TMUX_VERSION_MAJOR} -eq 2 -a #{$TMUX_VERSION_MINOR} -ge 6 \)'" 'set -g default-terminal "screen-256color"'
-if-shell "test '\( #{$TMUX_VERSION_MAJOR} -eq 2 -a #{$TMUX_VERSION_MINOR} -ge 6 \)'" 'set -ga terminal-overrides ",screen-256color:Tc"'
-
-if-shell '\( #{$TMUX_VERSION_MAJOR} -eq 2 -a #{$TMUX_VERSION_MINOR} -lt 6\) -o #{$TMUX_VERSION_MAJOR} -le 1' 'set -g default-terminal "screen-256color"'
+# Colors ΓÇö true color passthrough so vim/terminal colorschemes render correctly
+set -g default-terminal "tmux-256color"
+set -ga terminal-overrides ",*:Tc"

--- a/vimrc
+++ b/vimrc
@@ -9,6 +9,11 @@ scriptencoding utf-8
 syntax on
 filetype off
 filetype plugin indent on
+if has('termguicolors')
+  let &t_8f = "\<Esc>[38;2;%lu;%lu;%lum"
+  let &t_8b = "\<Esc>[48;2;%lu;%lu;%lum"
+  set termguicolors
+endif
 colorscheme molokai
 
 set nowritebackup


### PR DESCRIPTION
  - Change prefix from C-a to C-/ (bound as C-_ for terminal compatibility)
  - Update send-prefix passthrough binding to match new prefix
  - Enable true color (24-bit) passthrough: replace version-gated screen-256color blocks with tmux-256color + terminal-overrides ",*:Tc"
  - Add default key bindings reference comment block at top of config

  vimrc: enable termguicolors with explicit t_8f/t_8b escape sequences
  so vim renders molokai correctly inside and outside tmux